### PR TITLE
Fixed hidden table not opening on first click

### DIFF
--- a/memcache_status/templates/memcache_status/index.html
+++ b/memcache_status/templates/memcache_status/index.html
@@ -28,10 +28,6 @@ div.cache_stats table tbody th.cache_title{
     padding-top: 1em;
 }
 
-div.cache_stats tbody{
-    display: none;
-}
-
 div.cache_graph{
     height: 1em;
     width: 100%;
@@ -79,7 +75,7 @@ div.cache_graph_value{
             </div>
         </td></tr>
         </thead>
-        <tbody id="cache{{ forloop.counter }}">
+        <tbody id="cache{{ forloop.counter }}" style="display: none;">
         <tr>
             <th>{% trans "Miss Ratio" %}</th>
             <td>


### PR DESCRIPTION
The expanded table did not open on first click in Chrome and Safari, needed two clicks.
