### PR TITLE
New template tag for preventing graphs running out of table

### DIFF
--- a/memcache_status/templates/memcache_status/index.html
+++ b/memcache_status/templates/memcache_status/index.html
@@ -71,7 +71,7 @@ div.cache_graph_value{
         <thead>
         <tr><td colspan="2">
             <div class="cache_graph">
-                <div class="cache_graph_value" style="width: {% widthratio server.1.bytes server.1.limit_maxbytes 100 %}%"></div>
+                <div class="cache_graph_value" style="width: {% safewidthratio server.1.get_misses server.1.cmd_get 100 %}%"></div>
             </div>
         </td></tr>
         </thead>
@@ -81,14 +81,14 @@ div.cache_graph_value{
             <td>
                 {% widthratio server.1.get_misses server.1.cmd_get 100 %}%
                 <div class="cache_graph inline">
-                    <div class="cache_graph_value" style="width: {% widthratio server.1.get_misses server.1.cmd_get 100 %}%"></div>
+                    <div class="cache_graph_value" style="width: {% safewidthratio server.1.get_misses server.1.cmd_get 100 %}%"></div>
                 </div>
             </td>
         </tr>
         <tr>
             <th>{% trans "Avg GET by item" %}</th>
             <td>{% widthratio server.1.cmd_get server.1.total_items 1 %}</td>
-        </tr>        
+        </tr>
         <tr>
             <th>{% trans "Avg GET by seconds/minutes" %}</th>
             <td>{% widthratio server.1.cmd_get server.1.uptime 1 %}/{% widthratio server.1.cmd_get server.1.uptime 60 %}</td>


### PR DESCRIPTION
Hi.

I've found that, when going up to more than 100%, the graphs goes out of the data table.

In order to correct this and keep the graph bar inside the table, I slightly modified the Django `widthratio` template tag, which you are using to render the percentages and draw the graphs. This template tag can be found in `django.template.defaulttags`.

So, what I exactly did is to copy this tag functionality, but limit the output number to a maximum of 100%, so when you have data which passes it, it will stop at 100% instead of, for example, drawing a 800% bar. You can use this `safewidthratio` tag wherever in the HTML you are going to render a graph bar, keeping the `widthratio` tag in places where you render the exact number as a string, so you can get the table representing good data, but with the graphs inside the table.

I attach two images, before and after my code, so you can see more exactly what I mean.

Before my additions:
![screen shot 2013-06-21 at 3 30 42 pm](https://f.cloud.github.com/assets/2226098/691944/b030d758-dbde-11e2-948a-55daaa6692b0.png)

After my additions:
![screen shot 2013-06-23 at 10 15 18 am](https://f.cloud.github.com/assets/2226098/691945/be46ea76-dbde-11e2-9a09-826c512a83e2.png)

Hope you find this useful.

Cheers.
